### PR TITLE
fix[R6-42]: refactor funcion void falar

### DIFF
--- a/classes/pessoaImpl.dart
+++ b/classes/pessoaImpl.dart
@@ -26,10 +26,11 @@ class PessoaImpl extends Pessoa{
   }
 
   @override
-  void falar(String nome){
+  void falar(String texto){
 
-    print('${nome} diz: olá, tudo bem?');
+    print('${this.nome} diz: ${texto}');
   }
+
 
   
 }


### PR DESCRIPTION
Alterada função falar de 
  void falar(String nome){

    print('${nome} diz: Olá, tudo bem?');
  }
Para:
  void falar(String texto){

    print('${this.nome} diz: ${texto}');
  }

Reli o documento do projeto e fiz a alteração para que o texto seja recebido como parâmetro, o nome vai ser dinâmico também pois está pegando o nome instanciado da própria classe.

![Captura de tela 2024-03-31 203253](https://github.com/luarakerlen/koru-mobile-projeto-3/assets/118363325/49334c35-94a6-436e-bdf7-62a950493dc5)


![Captura de tela 2024-03-31 203630](https://github.com/luarakerlen/koru-mobile-projeto-3/assets/118363325/84540b9b-ad1d-45d1-be8c-069f2c47a8d9)
